### PR TITLE
DAC takes 8 bit unsigned values.

### DIFF
--- a/src/flite_out_arduino.h
+++ b/src/flite_out_arduino.h
@@ -194,8 +194,9 @@ class FliteOutputI2S : public  FliteOutputBase {
                 // copy from 1 to 2 channels
                 int total = 0;
                 int16_t *ptr = (int16_t *) buffer;
+								int16_t convertUnsigned=(i2s_config.mode & I2S_MODE_DAC_BUILT_IN)?0x8000:0;
                 for (int j=0;j<sample_count;j++){
-                    int16_t data[2] = {ptr[j], ptr[j]};
+                    int16_t data[2] = {ptr[j] + convertUnsigned, ptr[j] + convertUnsigned};
                     if (i2s_write(i2s_num, data, sizeof(int16_t)*2, &i2s_bytes_write, portMAX_DELAY)==ESP_OK){
                         total += i2s_bytes_write;
                     } else {


### PR DESCRIPTION
Whilst the 8 MSBs are use automatically by I2S we need to add 0x8000 in case of internal DAC
operation in order to get a range of 0 to 255